### PR TITLE
Strip debug symbols to reduce binary file size

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,3 +1,9 @@
-cargo build --features all --release
-cargo install --features all --root "%PREFIX%"
-IF %ERRORLEVEL% NEQ 0 exit 1
+:: build
+cargo build   --features all --release         || goto :error
+cargo install --features all --root "%PREFIX%" || goto :error
+
+goto :EOF
+
+:error
+echo Failed with error #%errorlevel%.
+exit 1

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -2,6 +2,8 @@
 cargo build   --features all --release         || goto :error
 cargo install --features all --root "%PREFIX%" || goto :error
 
+:: strip debug symbols
+strip "%PREFIX%\bin\tokei.exe" || goto :error
 goto :EOF
 
 :error

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,3 +5,6 @@ set -o xtrace -o nounset -o pipefail -o errexit
 # build statically linked binary with Rust
 cargo build --features all --release
 cargo install --features all --root "$PREFIX"
+
+# strip debug symbols
+strip "$PREFIX/bin/tokei"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+
+set -o xtrace -o nounset -o pipefail -o errexit
 
 # build statically linked binary with Rust
 cargo build --features all --release

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,7 @@
 {% set version = "8.0.1" %}
 
+{% set native = 'm2w64-' if win else '' %}
+
 package:
   name: tokei
   version: {{ version }}
@@ -9,11 +11,13 @@ source:
   sha256: 9d365695e3c790747d982bf0dc598f2a65b7e51b90fa98d4f34dfef72a019e13
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
     - rust
+    - binutils              # [linux]
+    - {{native}}binutils    # [win]
 
 test:
   commands:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
